### PR TITLE
Move warning to README and download pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ local.properties
 #################
 
 target/
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 #CHDangerous
 
+####WARNING!
+CHDangerous contains functions that if used incorrectly can ruin your life. PLEASE make sure you know what you are
+doing. ANY DAMAGE DONE IS SOLEY THE RESPONSIBILITY OF THE SERVER OWNER / MAINTAINER. ANYTHING CONTAINED IN THIS
+EXTENSION IS NOT GUARANTEED TO EVEN DO WHAT IT WAS DESIGNED TO DO.
 
 # Functions
 ## Void chd\_delete(File):

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.brothercraft</groupId>
 	<artifactId>CHDangerous</artifactId>
-	<version>1.0</version>
+	<version>1.0.1</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8-R0.1-SNAPSHOT</version>
+			<version>1.8.7-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/com/aczchef/chdangerous/LifeCycle.java
+++ b/src/main/java/com/aczchef/chdangerous/LifeCycle.java
@@ -2,14 +2,10 @@
 package com.aczchef.chdangerous;
 
 import com.laytonsmith.PureUtilities.SimpleVersion;
-import com.laytonsmith.PureUtilities.TermColors;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.core.extensions.AbstractExtension;
 import com.laytonsmith.core.extensions.MSExtension;
 
-/**
- *
- */
 @MSExtension("CHDangerous")
 public class LifeCycle extends AbstractExtension {
 
@@ -19,16 +15,12 @@ public class LifeCycle extends AbstractExtension {
 
 	@Override
 	public void onStartup() {
-		System.out.println(TermColors.BLINKON + TermColors.BG_RED + TermColors.BRIGHT_WHITE + "");
-		System.out.println(TermColors.BLINKON + TermColors.BG_RED + TermColors.BRIGHT_WHITE + "============================ [CHDangerous] ============================ ");
-		System.out.println(TermColors.BLINKON + TermColors.BG_RED + TermColors.BRIGHT_WHITE + "[WARNING]: CHDangerous contains functions that if used incorrectly can ruin your life.");
-		System.out.println(TermColors.BLINKON + TermColors.BG_RED + TermColors.BRIGHT_WHITE + "PLEASE make sure you know what you are doing.");
-		System.out.println(TermColors.BLINKON + TermColors.BG_RED + TermColors.BRIGHT_WHITE + "ANY DAMAGE DONE IS SOLEY THE RESPONSIBILITY OF THE SERVER OWNER / MAINTAINER.");
-		System.out.println(TermColors.BLINKON + TermColors.BG_RED + TermColors.BRIGHT_WHITE + "ANYTHING CONTAINED IN THIS EXTENSION IS NOT GUARANTEED TO EVEN DO WHAT IT WAS DESIGNED TO DO");
-		System.out.println(TermColors.BLINKON + TermColors.BG_RED + TermColors.BRIGHT_WHITE + "=======================================================================" + TermColors.BLINKOFF + TermColors.RESET);
-		System.out.println(" ");
+		System.out.println("CHDangerous " + getVersion() + " loaded.");
 	}
-	
-	
+
+	@Override
+	public void onShutdown() {
+		System.out.println("CHDangerous " + getVersion() + " unloaded.");
+	}
 
 }


### PR DESCRIPTION
I don't think it's necessary to hammer in the warning every time they recompile.